### PR TITLE
fix(ci): keep Agent verification output out of workspace

### DIFF
--- a/.github/workflows/public-validate.yml
+++ b/.github/workflows/public-validate.yml
@@ -527,7 +527,8 @@ jobs:
             --source-revision-digest "$SOURCE_REVISION_DIGEST" \
             --public-export-root "$GITHUB_WORKSPACE" \
             --public-provenance-sha256 "$PUBLIC_PROVENANCE_SHA256" \
-            --json | tee dist/agent-bundle-verification.json
+            --json | tee "$RUNNER_TEMP/agent-bundle-verification.json"
+          cp "$RUNNER_TEMP/agent-bundle-verification.json" dist/agent-bundle-verification.json
           cosign verify-blob \
             --bundle "$BUNDLE_DIR/agent-bundle.sigstore.json" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \


### PR DESCRIPTION
修复 Agent 镜像发布前的清单摘要校验失败。

原因：校验器扫描整个公开工作区，而校验命令先通过 `tee dist/agent-bundle-verification.json` 创建了新文件，导致实际摘要与私有构建时的基准摘要不一致。

修复：先将校验 JSON 写入 `$RUNNER_TEMP`，校验完成后再复制到 `dist/` 供 artifact 上传。

验证：
- `node scripts/ci/check-public-release-policy.mjs --root-dir . --public-only --json`
- `git diff --check`
- 使用 v0.0.1-alpha.72 公开树复现验证通过