### PR TITLE
chore(export): generated deployment projection v0.0.1-alpha.83

### DIFF
--- a/.github/workflows/public-validate.yml
+++ b/.github/workflows/public-validate.yml
@@ -804,8 +804,8 @@ jobs:
       - name: Attest public Engine Runtime release receipt
         uses: actions/attest-build-provenance@v2
         with:
+          # File attestations use GitHub Attestations; registry delivery only supports OCI image subjects.
           subject-path: dist/public-engine-runtime/build-results.json
-          push-to-registry: true
       - uses: actions/upload-artifact@v4
         with:
           name: public-engine-runtime-evidence-${{ github.sha }}


### PR DESCRIPTION
修复公开 Engine Runtime 发布中 JSON receipt 的 provenance attestation 配置。

push-to-registry: true 只适用于带完整 OCI subject-name 和 subject-digest 的镜像；receipt 使用 subject-path，应由 GitHub Attestations API 保存。

该 PR 只更新公开仓库自持有的 workflow；公开投影 manifest 与其他源文件保持不变。下一个版本导出会携带本次已修正的工作流。

验证：
- node scripts/ci/check-public-export.mjs --require-agent-bundle --json
- node scripts/ci/check-public-release-policy.mjs --root-dir . --public-only --json
- 私有仓库：node scripts/ci/publish-public-export-selftest.mjs
- 私有仓库：make verify-release-contract