### PR TITLE
chore(export): generated deployment projection v0.0.1-alpha.86

### DIFF
--- a/.github/workflows/public-validate.yml
+++ b/.github/workflows/public-validate.yml
@@ -1293,7 +1293,9 @@ jobs:
           node scripts/ci/generate-public-channel.mjs \
             --tag "$RELEASE_TAG" --channel "$channel" --manifest dist/final/release.manifest.yaml \
             --output-dir "$channel_root" --publication-complete
-          node scripts/ci/check-public-channel.mjs --root-dir "$channel_root" --require-first-release
+          # The first successful publication can follow the frozen source
+          # first tag, so do not manufacture a historical channel record.
+          node scripts/ci/check-public-channel.mjs --root-dir "$channel_root"
           rm -rf "$channel_worktree/channels" "$channel_worktree/manifests"
           mkdir -p "$channel_worktree/channels" "$channel_worktree/manifests"
           cp -a "$channel_root/channels/." "$channel_worktree/channels/"


### PR DESCRIPTION
Validate the actual append-only release-channel records when the first successful publication follows the frozen source first tag, rather than requiring a manufactured historical alpha.57 record.