### PR TITLE
chore(export): generated deployment projection v0.0.1-alpha.89

### DIFF
--- a/.github/workflows/public-validate.yml
+++ b/.github/workflows/public-validate.yml
@@ -753,7 +753,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: public-engine-runtime-discovery-${{ github.sha }}
-          path: dist
+          path: dist/public-engine-runtime-discovery
       - uses: actions/setup-go@v5
         with:
           go-version-file: tools/engine-release/go.mod
@@ -830,7 +830,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: public-engine-runtime-discovery-${{ github.sha }}
-          path: dist
+          path: dist/public-engine-runtime-discovery
       - uses: actions/download-artifact@v4
         with:
           pattern: public-engine-runtime-shard-${{ github.sha }}-*


### PR DESCRIPTION
Fix the destination-owned workflow artifact download layout for the v0.0.1-alpha.89 projection. Both the matrix build and receipt aggregation jobs now restore the discovery artifact at its canonical path.